### PR TITLE
Feature: List sponsors on the Project

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,6 @@ GEM
     nokogiri (1.5.0)
     orm_adapter (0.0.6)
     ox (1.5.0)
-    pg (0.13.2)
     polyamorous (0.5.0)
       activerecord (~> 3.0)
     polyglot (0.3.3)
@@ -245,7 +244,6 @@ DEPENDENCIES
   nested_form!
   nifty-generators
   ox
-  pg
   rails (= 3.2.2)
   rails_admin!
   rspec-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,8 @@
 //= require_tree .
 //
 $(document).ready (function() {
-$('.tabs').tabs();
-$('.my-tab-content').pills();
-$('a.cities').hover(function(){$('.submenu').show();});
+	$('.tabs').tabs();
+	$('.my-tab-content').pills();
+	$('a.cities').hover(function(){$('.submenu').show();});
+	
 });

--- a/app/assets/javascripts/projects.js
+++ b/app/assets/javascripts/projects.js
@@ -2,5 +2,6 @@ $(document).ready(function () {
   $('.datepicker').datepicker({
     dateFormat : "yy-mm-dd"
   });
+  $("a.close").on("click", function(){$("div.alert").fadeOut()});
 });
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,10 +9,16 @@ class Project < ActiveRecord::Base
   has_many :activities
   has_many :survey_responses, :as => :surveyable
   has_many :stories
+
+  has_many :project_sponsors, :dependent => :destroy
+  has_many :sponsors, :through => :project_sponsors
+
+
   accepts_nested_attributes_for :links, :allow_destroy => true
   accepts_nested_attributes_for :project_milestones, :allow_destroy => true
   accepts_nested_attributes_for :project_users, :allow_destroy => true
   accepts_nested_attributes_for :team_projects, :allow_destroy => true
+  accepts_nested_attributes_for :project_sponsors, :allow_destroy => true
   scope :active, where(:active => true)
   validates_presence_of :name
 

--- a/app/models/project_sponsor.rb
+++ b/app/models/project_sponsor.rb
@@ -1,0 +1,4 @@
+class ProjectSponsor < ActiveRecord::Base
+	belongs_to :project
+	belongs_to :sponsor
+end

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -1,0 +1,6 @@
+class Sponsor < ActiveRecord::Base
+	has_many :project_sponsors
+	has_many :projects, :through => :project_sponsors
+  	# Sponsor.create :name => "john", :identity => "Community Leader", :email => "john@domain.com", :link => "johnblog.com"
+  	# Sponsor.create :name => "jeffrey", :identity => "City Leader", :email => "jeffrey@domain.com", :link => "twitter/jeffrey.com"
+end

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -69,5 +69,12 @@
     =f.fields_for :team_projects do |u|
       = u.select(:team_id, Team.all.collect { |p| [p.name, p.id]}, {:include_blank => false})
       = u.link_to_remove "Remove"
+    %h2
+      Sponsors
+    = f.link_to_add "Add Sponsor",:project_sponsors
+    %p  
+    =f.fields_for :project_sponsors do |u|
+      = u.select(:sponsor_id, Sponsor.all.collect { |p| [p.name + " - " + p.identity, p.id]}, {:include_blank => false})
+      = u.link_to_remove "Remove"
   .actions
     = f.submit 'Save',{:class => "btn primary"}

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -26,6 +26,14 @@
           %br
           =link_to user.profile.name, user.profile
     .clearfix
+    %h2 Sponsors
+    %ul.team_members
+      -@project.sponsors.each do |sponor|
+        %li
+          =link_to gravatar_image_tag(sponor.email)
+          %br
+          =link_to sponor.name, "http://" + sponor.link
+    .clearfix
     %h2 Links
     %ul
       -@project.links.each do |link|

--- a/db/migrate/20120328214015_create_sponsors.rb
+++ b/db/migrate/20120328214015_create_sponsors.rb
@@ -1,0 +1,11 @@
+class CreateSponsors < ActiveRecord::Migration
+  def change
+    create_table :sponsors do |t|
+		t.string :name
+		t.string :identity 
+		t.string :email
+		t.string :link
+		t.timestamps
+    end
+  end
+end

--- a/db/migrate/20120328225527_create_project_sponsors.rb
+++ b/db/migrate/20120328225527_create_project_sponsors.rb
@@ -1,0 +1,9 @@
+class CreateProjectSponsors < ActiveRecord::Migration
+  def change
+    create_table :project_sponsors do |t|
+	    t.integer :project_id
+	  	t.integer :sponsor_id
+	    t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111216181649) do
+ActiveRecord::Schema.define(:version => 20120328225527) do
 
   create_table "activities", :force => true do |t|
     t.integer  "team_id"
@@ -103,6 +103,13 @@ ActiveRecord::Schema.define(:version => 20111216181649) do
     t.datetime "updated_at",                        :null => false
   end
 
+  create_table "project_sponsors", :force => true do |t|
+    t.integer  "project_id"
+    t.integer  "sponsor_id"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
   create_table "project_users", :force => true do |t|
     t.integer  "project_id"
     t.integer  "user_id"
@@ -131,6 +138,15 @@ ActiveRecord::Schema.define(:version => 20111216181649) do
   end
 
   add_index "rails_admin_histories", ["item", "table", "month", "year"], :name => "index_rails_admin_histories"
+
+  create_table "sponsors", :force => true do |t|
+    t.string   "name"
+    t.string   "identity"
+    t.string   "email"
+    t.string   "link"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
 
   create_table "stories", :force => true do |t|
     t.integer  "user_id"

--- a/spec/factories/project_sponsors.rb
+++ b/spec/factories/project_sponsors.rb
@@ -1,0 +1,6 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :project_sponsor, :class => 'ProjectSponsors' do
+  end
+end

--- a/spec/factories/sponsors.rb
+++ b/spec/factories/sponsors.rb
@@ -1,0 +1,6 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :sponsor do
+  end
+end

--- a/spec/models/project_sponsors_spec.rb
+++ b/spec/models/project_sponsors_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe ProjectSponsors do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/sponsor_spec.rb
+++ b/spec/models/sponsor_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Sponsor do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
I have implemented this feature, by adding a model for the Sponsors, and you can add Sponsors to the project after creating through edit form. To try this feature, add to Sponsors table this two rows and edit any project and you can add the sponsor.
`Sponsor.create :name => "john", :identity => "Community Leader",
:email => "john@domain.com", :link => "johnblog.com"
Sponsor.create :name => "jeffrey", :identity => "City Leader", 
:email => "jeffrey@domain.com", :link => "twitter/jeffrey.com"`
